### PR TITLE
Add missing default dependency craft recipes

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -906,4 +906,31 @@ elseif technic_path and farming and farming.mod and farming.mod == "redo" then
     })
 
    -- Recipes without technic & chains required.
+-- Recipes for default dependency fallback.
+else
+    minetest.register_craft({
+        output = "elevator:elevator",
+        recipe = {
+            {"default:steel_ingot", "farming:cotton", "default:steel_ingot"},
+            {"default:steel_ingot", "default:mese_crystal", "default:steel_ingot"},
+            {"xpanes:pane_flat", "default:glass", "xpanes:pane_flat"},
+        },
+    })
+
+    minetest.register_craft({
+        output = "elevator:shaft",
+        recipe = {
+            {"default:steel_ingot", "default:obsidian_glass"},
+            {"default:obsidian_glass", "default:steel_ingot"},
+        },
+    })
+
+    minetest.register_craft({
+        output = "elevator:motor",
+        recipe = {
+            {"default:diamond", "default:copper_ingot", "default:diamond"},
+            {"default:steelblock", "default:furnace", "default:steelblock"},
+            {"farming:cotton", "default:diamond", "farming:cotton"}
+        },
+    })
 end


### PR DESCRIPTION
Mod states it has no dependencies other than default, yet no recipes exist without technic/homedecor or farming redo. Tries to stay as true as possible to existing crafts.