### PR TITLE
Fix warning

### DIFF
--- a/helpers.lua
+++ b/helpers.lua
@@ -7,7 +7,7 @@ elevator.teleport_player_from_elevator = function(player)
         end
         return minetest.registered_nodes[minetest.get_node(pos).name].walkable
     end
-    local pos = vector.round(player:getpos())
+    local pos = vector.round(player:get_pos())
     local node = minetest.get_node(pos)
     -- elevator_off is like a shaft, so the player would already be falling.
     if node.name == "elevator:elevator_on" then

--- a/hooks.lua
+++ b/hooks.lua
@@ -12,7 +12,7 @@ minetest.register_globalstep(function(dtime)
     -- Only count riders who are still logged in.
     local newriding = {}
     for _,p in ipairs(minetest.get_connected_players()) do
-        local pos = p:getpos()
+        local pos = p:get_pos()
         local name = p:get_player_name()
         newriding[name] = elevator.riding[name]
         -- If the player is indeed riding, update their position.

--- a/init.lua
+++ b/init.lua
@@ -51,8 +51,8 @@ elevator.create_box = function(motorhash, pos, target, sender)
     obj:get_luaentity().halfway = {x=pos.x, y=(pos.y+target.y)/2, z=pos.z}
     obj:get_luaentity().vmult = (target.y < pos.y) and -1 or 1
     -- Set the speed.
-    obj:setvelocity({x=0, y=elevator.SPEED*obj:get_luaentity().vmult, z=0})
-    obj:setacceleration({x=0, y=elevator.ACCEL*obj:get_luaentity().vmult, z=0})
+    obj:set_velocity({x=0, y=elevator.SPEED*obj:get_luaentity().vmult, z=0})
+    obj:set_acceleration({x=0, y=elevator.ACCEL*obj:get_luaentity().vmult, z=0})
     -- Set the tables.
     elevator.boxes[motorhash] = obj
     elevator.riding[sender:get_player_name()] = {


### PR DESCRIPTION
This PR fixes this warning:
```
2021-04-24 07:18:42: WARNING[Server]: Call to deprecated function 'getpos', please use 'get_pos' at /home/minetest-pvp/.minetest/mods/elevator/hooks.lua:15
2021-04-24 07:45:48: WARNING[Server]: Call to deprecated function 'getpos', please use 'get_pos' at /home/minetest-pvp/.minetest/mods/elevator/helpers.lua:10
```