### PR TITLE
Add alternative crafting recipe for technic + basic materials (to eschew farming if also present)

### DIFF
--- a/crafts.lua
+++ b/crafts.lua
@@ -110,8 +110,8 @@ elseif technic_path and basic_materials_path then
         },
     })
 elseif technic_path and farming and farming.mod and ( farming.mod == "redo" or farming.mod == "undo" ) then
-   -- add alternative recipe with hemp rope
-       minetest.register_craft({
+    -- add alternative recipe with hemp rope
+    minetest.register_craft({
         output = "elevator:elevator_off",
         recipe = {
             {"technic:cast_iron_ingot", "farming:hemp_rope", "technic:cast_iron_ingot"},

--- a/crafts.lua
+++ b/crafts.lua
@@ -3,6 +3,7 @@ local technic_path = minetest.get_modpath("technic")
 local chains_path = minetest.get_modpath("chains")
 local mineclone_path = core.get_modpath("mcl_core") and mcl_core
 local aurum_path = core.get_modpath("aurum") and aurum
+local basic_materials_path = core.get_modpath("basic_materials")
 
 if mineclone_path then
    minetest.register_craft({
@@ -80,6 +81,32 @@ elseif technic_path and chains_path then
             {"default:diamond", "technic:control_logic_unit", "default:diamond"},
             {"default:steelblock", "technic:motor", "default:steelblock"},
             {"chains:chain", "default:diamond", "chains:chain"}
+        },
+    })
+elseif technic_path and basic_materials_path then
+    minetest.register_craft({
+        output = "elevator:elevator_off",
+        recipe = {
+            {"technic:cast_iron_ingot", "basic_materials:chain_steel", "technic:cast_iron_ingot"},
+            {"technic:cast_iron_ingot", "default:mese_crystal", "technic:cast_iron_ingot"},
+            {"technic:stainless_steel_ingot", "default:glass", "technic:stainless_steel_ingot"},
+        },
+    })
+
+    minetest.register_craft({
+        output = "elevator:shaft",
+        recipe = {
+            {"technic:cast_iron_ingot", "default:glass"},
+            {"default:glass", "basic_materials:chain_steel"},
+        },
+    })
+
+    minetest.register_craft({
+        output = "elevator:motor",
+        recipe = {
+            {"default:diamond", "technic:control_logic_unit", "default:diamond"},
+            {"default:steelblock", "technic:motor", "default:steelblock"},
+            {"basic_materials:chain_steel", "default:diamond", "basic_materials:chain_steel"}
         },
     })
 elseif technic_path and farming and farming.mod and ( farming.mod == "redo" or farming.mod == "undo" ) then

--- a/mod.conf
+++ b/mod.conf
@@ -1,4 +1,4 @@
 name = elevator
 description = An entity-based elevator allowing fast realtime travel in Minetest. Supports Minetest Game, MineClone2, and Aurum
-optional_depends = default, technic, homedecor, chains, farming, mcl_core, mcl_sounds, aurum, screwdriver, doc_items
+optional_depends = default, technic, homedecor, chains, farming, mcl_core, mcl_sounds, aurum, screwdriver, doc_items, basic_materials
 min_minetest_version = 5.4


### PR DESCRIPTION
Hi,

I'm using "farming redo" (not "chains", though), so I got the crafing recipe with the hemp rope. However, even though I've been playing with "farming redo" since I don't even know how long, through how many games, I NEVER, in none of my games, have found hemp anywhevere, ever, at all. So this recipe is basically uncraftable for me. However, I'm also using "basic_materials", which has a perfectly good steel chain item, so I added an alternative crafting recipe using that instead of the hemp rope, _above_ the "farming" recipe to make sure that if "basic_materials" is also available, then that will be used instead of the one with hemp.

Tried it, worked fine for me. Thought I submit it as a PR in case others would also struggle with the same issue.